### PR TITLE
Stop UrlAnnotation and LinkAnnotations from being stripped

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
   ext.versions = [
     compileSdk: 32,
-    composeUi: '1.2.0-rc02',
+    composeUi: '1.7.0-beta06',
   ]
 
   repositories {

--- a/extendedspans/src/main/kotlin/me/saket/extendedspans/ExtendedSpans.kt
+++ b/extendedspans/src/main/kotlin/me/saket/extendedspans/ExtendedSpans.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.ExperimentalTextApi
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.buildAnnotatedString
 import me.saket.extendedspans.internal.fastFold
@@ -46,6 +47,16 @@ class ExtendedSpans(
       }
       text.getTtsAnnotations(start = 0, end = text.length).fastForEach {
         addTtsAnnotation(it.item, it.start, it.end)
+      }
+      @Suppress("DEPRECATION")
+      text.getUrlAnnotations(start = 0, end = text.length).fastForEach {
+        addUrlAnnotation(it.item, it.start, it.end)
+      }
+      text.getLinkAnnotations(start = 0, end = text.length).fastForEach { range ->
+        when (val item = range.item) {
+          is LinkAnnotation.Url -> addLink(item, range.start, range.end)
+          is LinkAnnotation.Clickable -> addLink(item, range.start, range.end)
+        }
       }
     }
   }


### PR DESCRIPTION
Since the last release, it looks like a few new annotations have been added for linkified text. I bumped this to latest compose beta in order to add support for `UrlAnnotation` and `LinkAnnotation`.